### PR TITLE
Decrease bd_XRayImaging EC rate

### DIFF
--- a/System/ScienceRework/Tweakables/BDBExperiments.cfg
+++ b/System/ScienceRework/Tweakables/BDBExperiments.cfg
@@ -318,7 +318,7 @@
 			size = 76696
 			value = 5600
 			duration = 172800000 // 2000 days
-			ec_rate = 23
+			ec_rate = 2.3
 		}
 	}
 }


### PR DESCRIPTION
23 EC/s is kinda way too high. AOO telescope can only produce ~9.21 EC/s in sunlight. Considering the experiment run for years, this is likely a typo. I selected 2.3 because the likeliest typo is missing a character (or inverting characters). Also, the UV telescope uses 2.1 EC/s... So close but not the same.